### PR TITLE
bug? helm deploy fails when attempting to patch in values

### DIFF
--- a/examples/profile-patches/skaffold.yaml
+++ b/examples/profile-patches/skaffold.yaml
@@ -30,5 +30,11 @@ profiles:
           image: skaffold-world
           context: world-service
       - op: add
-        path: /deploy/kubectl/manifests/1
-        value: 'world-service/*.yaml'
+        path: /deploy/helm
+        value:
+          releases:
+            - name: world
+              chartPath: world-service/helm
+              values:
+                foo: bar
+                image: skaffold-world

--- a/examples/profile-patches/world-service/helm/.helmignore
+++ b/examples/profile-patches/world-service/helm/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/examples/profile-patches/world-service/helm/Chart.yaml
+++ b/examples/profile-patches/world-service/helm/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: helm
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.0

--- a/examples/profile-patches/world-service/helm/templates/k8s-pod.yaml
+++ b/examples/profile-patches/world-service/helm/templates/k8s-pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
   - name: world-service
-    image: skaffold-world
+    image: {{ .Values.image }}

--- a/examples/profile-patches/world-service/helm/values.yaml
+++ b/examples/profile-patches/world-service/helm/values.yaml
@@ -1,0 +1,2 @@
+image: skaffold-world
+foo: bar


### PR DESCRIPTION
Greetings, thanks for your work on this project, very useful tool.

I am attempting to write json patches which update the `values` section in helm deploy.

With just an image things seem to go ok but as soon as I add the `foo: bar` variable I get
 > FATA[0000] exiting dev mode because first deploy failed: deploying "world": release args:
> matching build results to chart values: no build present for bar

I'm not sure why skaffold is interpreting `foo` as a build it's just an arbitrary value.

I may well have misunderstood something basic here but I can't find an example of profiles being used in combination with helm so I'm feeling my way through, any assistance appreciated.

Many thanks

Ollie